### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Run Tests


### PR DESCRIPTION
Potential fix for [https://github.com/lordmathis/lemma/security/code-scanning/6](https://github.com/lordmathis/lemma/security/code-scanning/6)

To fix the issue, add a `permissions` block to the workflow. Since the workflow only needs to read the repository contents (e.g., to check out the code), the minimal required permission is `contents: read`. This block can be added at the root level of the workflow to apply to all jobs, or specifically to the `test` job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
